### PR TITLE
Fix parallelization by fixing pickling and un-pickling of CADET-dll

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -6,6 +6,8 @@ import subprocess
 from typing import Optional
 import warnings
 
+from addict import Dict
+
 from cadet.h5 import H5
 from cadet.runner import CadetRunnerBase, CadetCLIRunner, ReturnInformation
 from cadet.cadet_dll import CadetDLLRunner
@@ -525,3 +527,12 @@ class Cadet(H5, metaclass=CadetMeta):
         self.clear()
         del self._cadet_dll_runner
         del self._cadet_cli_runner
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        # Restore the state and cast to addict.Dict() to add __frozen attributes
+        state = Dict(state)
+        self.__dict__.update(state)

--- a/cadet/cadet_dll.py
+++ b/cadet/cadet_dll.py
@@ -1626,6 +1626,9 @@ class CadetDLLRunner(CadetRunnerBase):
             Path to the CADET DLL.
         """
         self._cadet_path = Path(dll_path)
+        self._initialize_dll()
+
+    def _initialize_dll(self):
         self._lib = ctypes.cdll.LoadLibrary(self._cadet_path.as_posix())
 
         # Query meta information
@@ -1692,6 +1695,18 @@ class CadetDLLRunner(CadetRunnerBase):
 
         self._driver = self._api.createDriver()
         self.res: Optional[SimulationResult] = None
+
+    def __getstate__(self):
+        # Exclude all non-pickleable attributes and only keep _cadet_path
+        state = self.__dict__.copy()
+        pickleable_keys = ["_cadet_path"]
+        state = {key: state[key] for key in pickleable_keys}
+        return state
+
+    def __setstate__(self, state):
+        # Restore the state and reinitialize the DLL
+        self.__dict__.update(state)
+        self._initialize_dll()
 
     def clear(self) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-testing = ["pytest"]
+testing = [
+    "pytest",
+    "joblib"
+]
 
 [project.urls]
 "homepage" = "https://github.com/cadet/CADET-Python"

--- a/tests/test_parallelization.py
+++ b/tests/test_parallelization.py
@@ -1,0 +1,40 @@
+from cadet import Cadet
+from joblib import Parallel, delayed
+from .test_dll import setup_model
+
+n_jobs = 2
+
+
+def run_simulation(model):
+    model.save()
+    data = model.run_load()
+    return data
+
+
+def test_parallelization_io():
+    model1 = Cadet()
+    model1.root.input = {'model': 1}
+    model1.filename = "sim_1.h5"
+    model2 = Cadet()
+    model2.root.input = {'model': 2}
+    model2.filename = "sim_2.h5"
+
+    models = [model1, model2]
+
+    results_sequential = [run_simulation(model) for model in models]
+
+    results_parallel = Parallel(n_jobs=n_jobs, verbose=0)(
+        delayed(run_simulation)(model, ) for model in models
+    )
+    assert results_sequential == results_parallel
+
+
+def test_parallelization_simulation():
+    models = [setup_model(Cadet.autodetect_cadet(), file_name=f"LWE_{i}.h5") for i in range(2)]
+
+    results_sequential = [run_simulation(model) for model in models]
+
+    results_parallel = Parallel(n_jobs=n_jobs, verbose=0)(
+        delayed(run_simulation)(model, ) for model in models
+    )
+    assert results_sequential == results_parallel


### PR DESCRIPTION
As described in https://github.com/cadet/CADET-Python/issues/25  with CADET-Python v1.0.0 the parallelization is broken because we can not pickle ctype pointers. 

My proposed solution is to remove all pointers from the state, only save the `_cadet_path` and then on `__getstate__` re-load the dll and pointers in the child-thread.

ToDo:
- [x] Fix pickling
- [x] Add test