### PR TITLE
Fix errors of solution not loading if only one UnitOperation was returned

### DIFF
--- a/cadet/cadet_dll.py
+++ b/cadet/cadet_dll.py
@@ -1880,10 +1880,10 @@ class CadetDLLRunner(CadetRunnerBase):
             unit_solution.update(self._load_solution_trivial(sim, unit, 'soldot_flux'))
             unit_solution.update(self._load_solution_trivial(sim, unit, 'soldot_volume'))
 
-            if len(unit_solution) > 1:
+            if len(unit_solution) > 0:
                 solution[unit_index].update(unit_solution)
 
-        if len(solution) > 1:
+        if len(solution) > 0:
             sim.root.output.solution.update(solution)
 
         return solution


### PR DESCRIPTION
For high-throughput simulations I removed all returns except for my UO of interest. Then, with the DLL runner I was getting empty solutions. This PR fixes that by ensuring the length of the solution is larger than 0, instead of larger than 1, before adding it to the full solution. 

@schmoelder  do you remember if there was a reason for `> 1` ?