### PR TITLE
Add a CadetDockerRunner and tests

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -9,7 +9,7 @@ import warnings
 from addict import Dict
 
 from cadet.h5 import H5
-from cadet.runner import CadetRunnerBase, CadetCLIRunner, ReturnInformation
+from cadet.runner import CadetRunnerBase, CadetCLIRunner, ReturnInformation, CadetDockerRunner
 from cadet.cadet_dll import CadetDLLRunner
 
 
@@ -184,7 +184,10 @@ class Cadet(H5, metaclass=CadetMeta):
         Stores the information returned after a simulation run.
     """
 
-    def __init__(self, install_path: Optional[Path] = None, use_dll: bool = False, *data):
+    def __init__(
+            self, install_path: Optional[Path] = None, use_dll: bool = False,
+            docker_container: Optional[str] = None, *data
+    ):
         """
         Initialize a new instance of the Cadet class.
         Priority order of install_paths is:
@@ -194,6 +197,12 @@ class Cadet(H5, metaclass=CadetMeta):
 
         Parameters
         ----------
+        install_path : Optional[Path]
+            The root directory of the CADET installation.
+        use_dll : Optional[bool]
+            Indicates whether to use a DLL or a CLI executable.
+        docker_container : Optional[str]
+            Label of the docker container to use.
         *data : tuple
             Additional data to be passed to the H5 base class initialization.
         """
@@ -207,6 +216,12 @@ class Cadet(H5, metaclass=CadetMeta):
             self.use_dll = use_dll
             self.install_path = install_path  # This will set _cadet_dll_runner and _cadet_cli_runner
             return
+
+        # If we get a docker_container, we use the docker container
+        if docker_container is not None:
+            self._cadet_docker_runner: Optional[CadetDockerRunner] = CadetDockerRunner(
+                docker_container
+            )
 
         # If _cadet_cli_runner_class has been set in the Meta Class, use them, else instantiate Nones
         if hasattr(self, "cadet_cli_path") and self.cadet_cli_path is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ testing = [
     "pytest",
     "joblib"
 ]
+docker = [
+    "docker"
+]
 
 [project.urls]
 "homepage" = "https://github.com/cadet/CADET-Python"
@@ -57,4 +60,5 @@ testpaths = ["tests"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "local: marks tests as only useful on local installs (deselect with '-m \"not local\"')",
+    "docker: marks tests as requiring a docker installation (deselect with '-m \"not docker\"')",
 ]

--- a/tests/docker_resources/Dockerfile
+++ b/tests/docker_resources/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+ARG MAMBA_VERSION=1.5.8
+FROM mambaorg/micromamba:${MAMBA_VERSION}-focal AS base
+
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
+
+RUN micromamba install -y -n base -f /tmp/environment.yml && \
+    micromamba clean --all --yes
+
+WORKDIR /opt/conda/bin

--- a/tests/docker_resources/environment.yml
+++ b/tests/docker_resources/environment.yml
@@ -1,0 +1,6 @@
+name: cadet
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - cadet

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -1,0 +1,67 @@
+import os
+import docker
+import pytest
+
+from cadet import Cadet
+from cadet.runner import CadetDockerRunner
+from tests.test_dll import setup_model
+
+os.chdir("docker_resources")
+
+
+@pytest.fixture
+def my_docker_image_tag():
+    client = docker.from_env()
+
+    image, logs = client.images.build(
+        path=".",
+        tag="cadet-docker-test",
+        quiet=False,
+    )
+
+    # for log in logs:
+    #     print(log)
+
+    return_info = client.containers.run(
+        image=image,
+        command="cadet-cli --version"
+    )
+
+    if len(return_info.decode()[:10000]) < 1:
+        raise RuntimeError("Docker build went wrong.")
+    return image.tags[0]
+
+
+@pytest.mark.local
+@pytest.mark.docker
+def test_docker_version(my_docker_image_tag):
+    runner = CadetDockerRunner(my_docker_image_tag)
+    assert len(runner.cadet_version) > 0
+    assert len(runner.cadet_branch) > 0
+    assert len(runner.cadet_build_type) > 0
+    assert len(runner.cadet_commit_hash) > 0
+
+@pytest.mark.local
+@pytest.mark.docker
+def test_docker_runner(my_docker_image_tag):
+    model = setup_model(Cadet.autodetect_cadet(), file_name=f"LWE_docker.h5")
+    runner = CadetDockerRunner(my_docker_image_tag)
+    runner.run(model)
+    model.load()
+    assert hasattr(model.root, "output")
+    assert hasattr(model.root.output, "solution")
+    assert hasattr(model.root.output.solution, "unit_000")
+
+
+@pytest.mark.local
+@pytest.mark.docker
+def test_docker_run(my_docker_image_tag):
+    simulator = Cadet(docker_container=my_docker_image_tag)
+    simulator.filename = "LWE_docker.h5"
+    simulator.save()
+    model = setup_model(Cadet.autodetect_cadet(), file_name=f"LWE_docker.h5")
+    simulator.root.input.update(model.root.input)
+    simulator.run_load()
+    assert hasattr(simulator.root, "output")
+    assert hasattr(simulator.root.output, "solution")
+    assert hasattr(simulator.root.output.solution, "unit_000")


### PR DESCRIPTION
```
This class runs CADET simulations using a command-line interface (CLI) executable that is
contained inside a Docker container. This expects the Docker container to have the
root/bin of the installation as the working folder. This gives us access to the cadet-cli and
tools such as createLWE.
```

ToDos:
- [ ] Add documentation
- [ ] Fix --version test (all other tests run)