### PR TITLE
Add missing dll tests

### DIFF
--- a/cadet/cadet_dll.py
+++ b/cadet/cadet_dll.py
@@ -2055,20 +2055,20 @@ class CadetDLLRunner(CadetRunnerBase):
                 if nPort == 1:
                     if single_as_multi_port:
                         for comp in range(nComp):
-                            comp_out = numpy.squeeze(out[..., comp])
+                            comp_out = out[..., 0, comp]
                             solution[f'{solution_str}_port_000_comp_{comp:03d}'] = comp_out
                     else:
                         for comp in range(nComp):
-                            comp_out = numpy.squeeze(out[..., comp])
+                            comp_out = out[..., comp]
                             solution[f'{solution_str}_comp_{comp:03d}'] = comp_out
                 else:
                     for port in range(nPort):
                         for comp in range(nComp):
-                            comp_out = numpy.squeeze(out[..., port, comp])
+                            comp_out = out[..., port, comp]
                             solution[f'{solution_str}_port_{port:03d}_comp_{comp:03d}'] = comp_out
             else:
                 for comp in range(nComp):
-                    comp_out = numpy.squeeze(out[..., comp])
+                    comp_out = out[..., comp]
                     solution[f'{solution_str}_comp_{comp:03d}'] = comp_out
         else:
             if split_ports_data:
@@ -2076,14 +2076,14 @@ class CadetDLLRunner(CadetRunnerBase):
                     if single_as_multi_port:
                         solution[f'{solution_str}_port_000'] = out
                     else:
-                        solution[solution_str] = numpy.squeeze(out[..., 0, :])
+                        solution[solution_str] = out[..., 0, :]
                 else:
                     for port in range(nPort):
-                        port_out = numpy.squeeze(out[..., port, :])
+                        port_out = out[..., port, :]
                         solution[f'{solution_str}_port_{port:03d}'] = port_out
             else:
                 if nPort == 1 and nPort_idx is not None:
-                    solution[solution_str] = numpy.squeeze(out[..., 0, :])
+                    solution[solution_str] = out[..., 0, :]
                 else:
                     solution[solution_str] = out
 

--- a/tests/test_dll.py
+++ b/tests/test_dll.py
@@ -83,7 +83,7 @@ def setup_model(
     interface.
     """
 
-    cadet_model = Cadet(install_path=cadet_root, use_dll=True)
+    cadet_model = Cadet(install_path=cadet_root, use_dll=use_dll)
 
     args = [
         cadet_model.cadet_create_lwe_path,

--- a/tests/test_dll.py
+++ b/tests/test_dll.py
@@ -140,8 +140,13 @@ def setup_model(
                          'lin_coeff': [0., ], 'quad_coeff': [0., ]},
              'sec_002': {'const_coeff': [100., ], 'cube_coeff': [0., ],
                          'lin_coeff': [0.2], 'quad_coeff': [0., ]}}
-
         )
+        # if we don't save and re-load the model we get windows access violations.
+        # Interesting case for future tests, not what I want to test now.
+        cadet_model.save()
+        cadet_model = Cadet(install_path=cadet_root, use_dll=use_dll)
+        cadet_model.filename = file_name
+        cadet_model.load()
 
     return cadet_model
 


### PR DESCRIPTION
The dll interface tests had two conditions that were not checked correctly:
1. The dll test was supposed to compare the dll interface to the cli interface, which was never actually called. One commit fixes that and now throws an error.
2. The dll test did not check for simulations with only one component. One commit adds a single-component case by modifying the simulation to only include one component. Now we get dimensionality errors.