### PR TITLE
v1.0.2

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,48 +19,48 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Get Date
-      id: get-date
-      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-      shell: bash
+      - name: Get Date
+        id: get-date
+        run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+        shell: bash
 
-    - name: Setup Conda Environment
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-variant: Mambaforge
-        use-mamba: true
-        activate-environment: cadet-python
-        channels: conda-forge,
+      - name: Setup Conda Environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          use-mamba: true
+          activate-environment: cadet-python
+          channels: conda-forge,
 
-    - name: Cache conda
-      uses: actions/cache@v3
-      env:
-        # Increase this value to reset cache if environment.yml has not changed
-        CACHE_NUMBER: 0
-      with:
-        path: ${{ env.CONDA }}/envs
-        key: python_${{ matrix.python-version }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}
+      - name: Cache conda
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ${{ env.CONDA }}/envs
+          key: python_${{ matrix.python-version }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}
 
-    - name: Set up python env
-      run: |
-        mamba install python==${{ matrix.python-version }}
-        pip install .
-    - name: Install pypa/build
-      run: |
-        python -m pip install build --user
+      - name: Set up python env
+        run: |
+          mamba install python==${{ matrix.python-version }}
+          pip install .
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
 
-    - name: Build binary wheel and source tarball
-      run: |
-        python -m build --sdist --wheel --outdir dist/ .
+      - name: Build binary wheel and source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
 
-    - name: Test Wheel install and import
-      run: |
-        python -c "import cadet; print(cadet.__version__)"
-        cd ..
-    - name: Test with pytest
-      run: |
-        pip install .[testing]
-        mamba install cadet -c conda-forge
-        pytest tests --rootdir=tests -m "not slow and not local"
+      - name: Test Wheel install and import
+        run: |
+          python -c "import cadet; print(cadet.__version__)"
+          cd ..
+      - name: Test with pytest
+        run: |
+          pip install .[testing]
+          mamba install cadet>5.0.2 -c conda-forge
+          pytest tests --rootdir=tests -m "not slow and not local"

--- a/cadet/__init__.py
+++ b/cadet/__init__.py
@@ -1,6 +1,6 @@
 name = 'CADET-Python'
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 from .h5 import H5
 from .cadet import Cadet


### PR DESCRIPTION
Open question: Should we pin the CADET-Core version in the CI pipeline? If so, where should we declare this?

Ideally, we should test different versions of CADET-Core (if we expect compatibility).

Note, before releasing, we should wait for CADET-Core v5.0.2 (see also: https://github.com/cadet/CADET-Core/milestone/10)

