### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To avoid upgrading issues such as https://github.com/fau-advanced-separations/CADET-Process/issues/229, we should consider adding something like [dependabot](https://github.com/dependabot) to automatically manage our dependencies.

Dependabot would need enabled requirements in the security [settings](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository). Depending on the settings it is possible to automaticly detect and manage our dependencies. On the downside, it is not able to check for conda, only for https://github.com/dependabot/dependabot-core/issues/2227 as ecosystem.

In the context of our current Issues, as far as i am understanding dependabot, it wouldn't have been able to detect https://github.com/fau-advanced-separations/CADET-Process/issues/229 earlier or at all, because libsqlite 3.49.1 is not a direct dependency of our environments but comes automaticly with diskcache.