### PR TITLE
Change load and run interface

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -31,13 +31,11 @@ def is_dll(path: os.PathLike) -> bool:
     return suffix in {'.so', '.dll'}
 
 
-def install_path_to_cadet_paths(
-        install_path: Optional[os.PathLike],
+def resolve_cadet_paths(
+        install_path: Optional[os.PathLike]
         ) -> tuple[Optional[Path], Optional[Path], Optional[Path], Optional[Path]]:
     """
-    Get the correct paths (root_path, cadet_cli_path, cadet_dll_path, cadet_create_lwe_path)
-     from the installation path of CADET. This is extracted into a function to be used
-     in both the meta class and the cadet class itself.
+    Resolve paths from the installation path of CADET.
 
     Parameters
     ----------
@@ -48,7 +46,7 @@ def install_path_to_cadet_paths(
     Returns
     -------
     tuple[Optional[Path], Optional[Path], Optional[Path], Optional[Path]]
-        Tuple with CADET installation paths
+        tuple with CADET installation paths
         (root_path, cadet_cli_path, cadet_dll_path, cadet_create_lwe_path)
     """
     if install_path is None:
@@ -75,16 +73,16 @@ def install_path_to_cadet_paths(
         lwe_executable += '.exe'
 
     cadet_cli_path = cadet_root / 'bin' / cli_executable
-    if cadet_cli_path.is_file():
-        cadet_cli_path = cadet_cli_path
-    else:
+    if not cadet_cli_path.is_file():
         raise FileNotFoundError(
-            "CADET could not be found. Please check the path."
+            "CADET CLI could not be found. Please check the path."
         )
 
     cadet_create_lwe_path = cadet_root / 'bin' / lwe_executable
-    if cadet_create_lwe_path.is_file():
-        cadet_create_lwe_path = cadet_create_lwe_path.as_posix()
+    if not cadet_create_lwe_path.is_file():
+        raise FileNotFoundError(
+            "CADET createLWE could not be found. Please check the path."
+        )
 
     if platform.system() == 'Windows':
         dll_path = cadet_root / 'bin' / 'cadet.dll'
@@ -97,10 +95,7 @@ def install_path_to_cadet_paths(
     if not dll_path.is_file() and dll_debug_path.is_file():
         dll_path = dll_debug_path
 
-    if dll_path.is_file():
-        cadet_dll_path = dll_path
-    else:
-        cadet_dll_path = None
+    cadet_dll_path = dll_path if dll_path.is_file() else None
 
     return root_path, cadet_cli_path, cadet_dll_path, cadet_create_lwe_path
 
@@ -112,6 +107,7 @@ class CadetMeta(type):
     This meta class allows setting the `cadet_path` attribute for all instances of the
     `Cadet` class.
     """
+
     use_dll = False
     cadet_cli_path = None
     cadet_dll_path = None
@@ -166,9 +162,10 @@ class CadetMeta(type):
 
         cls.use_dll = cadet_path.suffix in [".dll", ".so"]
 
-        _install_path, cadet_cli_path, cadet_dll_path, cadet_create_lwe_path = install_path_to_cadet_paths(cadet_path)
+        install_path, cadet_cli_path, cadet_dll_path, cadet_create_lwe_path = \
+            resolve_cadet_paths(cadet_path)
 
-        cls._install_path = _install_path
+        cls._install_path = install_path
         cls.cadet_create_lwe_path = cadet_create_lwe_path
         cls.cadet_cli_path = cadet_cli_path
         cls.cadet_dll_path = cadet_dll_path
@@ -178,8 +175,9 @@ class Cadet(H5, metaclass=CadetMeta):
     """
     CADET interface class.
 
-    This class manages the CADET runner, whether it's based on a CLI executable or a DLL,
-    and provides methods for running simulations and loading results.
+    This class manages the CADET runner, whether it's based on the CLI executable or
+    the in-memory interface and provides methods for running simulations and loading
+    results.
 
     Attributes
     ----------
@@ -195,9 +193,15 @@ class Cadet(H5, metaclass=CadetMeta):
         Stores the information returned after a simulation run.
     """
 
-    def __init__(self, install_path: Optional[Path] = None, use_dll: bool = False, *data):
+    def __init__(
+            self,
+            install_path: Optional[Path] = None,
+            use_dll: bool = False,
+            *data
+            ) -> None:
         """
         Initialize a new instance of the Cadet class.
+
         Priority order of install_paths is:
         1. install_path set in __init__ args
         2. install_path set in CadetMeta
@@ -216,13 +220,14 @@ class Cadet(H5, metaclass=CadetMeta):
         self._cadet_cli_runner: Optional[CadetCLIRunner] = None
         self._cadet_dll_runner: Optional[CadetDLLRunner] = None
 
-        # Regardless of settings in the Meta Class, if we get an install_path, we respect the install_path
+        # Regardless of settings in the Meta Class, if we get an install_path, we
+        # respect the install_path
         if install_path is not None:
             self.use_dll = use_dll
-            self.install_path = install_path  # This will set _cadet_dll_runner and _cadet_cli_runner
+            self.install_path = install_path  # This will automatically set the runners.
             return
 
-        # If _cadet_cli_runner_class has been set in the Meta Class, use them, else instantiate Nones
+        # Use CLIRunner of the Meta class, if provided.
         if hasattr(self, "cadet_cli_path") and self.cadet_cli_path is not None:
             self._cadet_cli_runner: Optional[CadetCLIRunner] = CadetCLIRunner(
                 self.cadet_cli_path
@@ -231,6 +236,7 @@ class Cadet(H5, metaclass=CadetMeta):
             self._cadet_cli_runner: Optional[CadetCLIRunner] = None
             self.use_dll = use_dll
 
+        # Use DLLRunner of the Meta class, if provided.
         if hasattr(self, "cadet_dll_path") and self.cadet_dll_path is not None:
             try:
                 self._cadet_dll_runner: Optional[CadetDLLRunner] = CadetDLLRunner(
@@ -244,11 +250,10 @@ class Cadet(H5, metaclass=CadetMeta):
             self._cadet_dll_runner: Optional[CadetCLIRunner] = None
             self.use_dll = use_dll
 
-        # If any runner has been set in the Meta Class, don't auto-detect Cadet, just return
         if self._cadet_cli_runner is not None or self._cadet_dll_runner is not None:
             return
 
-        # If neither Meta Class nor install_path are given: auto-detect Cadet
+        # Auto-detect Cadet if neither Meta Class nor install_path are given.
         self.install_path = self.autodetect_cadet()
 
     @property
@@ -271,7 +276,7 @@ class Cadet(H5, metaclass=CadetMeta):
         Parameters
         ----------
         install_path : Optional[os.PathLike]
-            Path to the root of the CADET installation or the executable file 'cadet-cli'.
+            Path to the root of the CADET installation or the 'cadet-cli' executable.
             If a file path is provided, the root directory will be inferred.
         """
         if install_path is None:
@@ -281,7 +286,8 @@ class Cadet(H5, metaclass=CadetMeta):
             self.cadet_create_lwe_path = None
             return
 
-        root_path, cadet_cli_path, cadet_dll_path, create_lwe_path = install_path_to_cadet_paths(install_path)
+        root_path, cadet_cli_path, cadet_dll_path, create_lwe_path = \
+            resolve_cadet_paths(install_path)
 
         self._install_path = root_path
         self.cadet_create_lwe_path = create_lwe_path
@@ -376,7 +382,6 @@ class Cadet(H5, metaclass=CadetMeta):
         Optional[CadetRunnerBase]
             The current runner instance, either a DLL or file-based runner.
         """
-
         if self.use_dll and self.found_dll:
             return self._cadet_dll_runner
 
@@ -487,7 +492,7 @@ class Cadet(H5, metaclass=CadetMeta):
         timeout : Optional[int]
             Maximum time allowed for the simulation to run, in seconds.
         clear : bool
-            If True, clean up the simulation after loading the results, e.g. reset the driver.
+            If True, clear the simulation results from the current runner instance.
 
         Returns
         -------
@@ -495,10 +500,12 @@ class Cadet(H5, metaclass=CadetMeta):
             Information about the simulation run.
         """
         warnings.warn(
-            message="Cadet.run_load() will be removed in a future release. Please use Cadet.run_simulation()",
+            "Cadet.run_load() will be removed in a future release. "
+            "Please use Cadet.run_simulation()",
             category=FutureWarning
         )
         return_information = self.run_simulation(timeout=timeout, clear=clear)
+
         return return_information
 
     def run_simulation(
@@ -514,7 +521,7 @@ class Cadet(H5, metaclass=CadetMeta):
         timeout : Optional[int]
             Maximum time allowed for the simulation to run, in seconds.
         clear : bool
-            If True, clean up the simulation after loading the results, e.g. reset the driver.
+            If True, clear the simulation results from the current runner instance.
 
         Returns
         -------
@@ -531,6 +538,7 @@ class Cadet(H5, metaclass=CadetMeta):
 
         if clear:
             self.clear()
+
         return return_information
 
     def run(
@@ -551,7 +559,8 @@ class Cadet(H5, metaclass=CadetMeta):
             Information about the simulation run.
         """
         warnings.warn(
-            message="Cadet.run() will be removed in a future release. Please use Cadet.run_simulation()",
+            "Cadet.run() will be removed in a future release. \n"
+            "Please use Cadet.run_simulation()",
             category=FutureWarning
         )
         return_information = self.cadet_runner.run(
@@ -564,9 +573,10 @@ class Cadet(H5, metaclass=CadetMeta):
     def load_results(self) -> None:
         """Load the results of the last simulation run into the current instance."""
         warnings.warn(
-            message="Cadet.load_results() will be removed in a future release. \n"
-            "    Please use Cadet.load_from_file() to load results from a file \n"
-            "    or use Cadet.run_simulation() to run a simulation and directly load the simulation results.",
+            "Cadet.load_results() will be removed in a future release. \n"
+            "Please use Cadet.load_from_file() to load results from a file "
+            "or use Cadet.run_simulation() to run a simulation and directly load the "
+            "simulation results.",
             category=FutureWarning
         )
         self.load_from_file()
@@ -574,15 +584,16 @@ class Cadet(H5, metaclass=CadetMeta):
     def load(self) -> None:
         """Load the results of the last simulation run into the current instance."""
         warnings.warn(
-            message="Cadet.load() will be removed in a future release. \n"
-            "    Please use Cadet.load_from_file() to load results from a file \n"
-            "    or use Cadet.run_simulation() to run a simulation and directly load the simulation results.",
+            "Cadet.load() will be removed in a future release. \n"
+            "Please use Cadet.load_from_file() to load results from a file or use "
+            "Cadet.run_simulation() to run a simulation and directly load the "
+            "simulation results.",
             category=FutureWarning
         )
         self.load_from_file()
 
     def clear(self) -> None:
-        """Clear the loaded results from the current instance."""
+        """Clear the simulation results from the current runner instance."""
         runner = self.cadet_runner
         if runner is not None:
             runner.clear()

--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -430,7 +430,7 @@ class Cadet(H5, metaclass=CadetMeta):
         self.load_from_file()
 
         if file_path_input is None:
-            os.remove(file_path)
+            self.delete_file()
 
         return self
 
@@ -597,13 +597,6 @@ class Cadet(H5, metaclass=CadetMeta):
         runner = self.cadet_runner
         if runner is not None:
             runner.clear()
-
-    def delete_file(self) -> None:
-        if self.filename is not None:
-            try:
-                os.remove(self.filename)
-            except FileNotFoundError:
-                pass
 
     def __del__(self):
         self.clear()

--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -422,7 +422,7 @@ class Cadet(H5, metaclass=CadetMeta):
 
         self.filename = file_path
 
-        self.load()
+        self.load_from_file()
 
         if file_path_input is None:
             os.remove(file_path)
@@ -487,17 +487,47 @@ class Cadet(H5, metaclass=CadetMeta):
         timeout : Optional[int]
             Maximum time allowed for the simulation to run, in seconds.
         clear : bool
-            If True, clear previous results after loading new ones.
+            If True, clean up the simulation after loading the results, e.g. reset the driver.
 
         Returns
         -------
         ReturnInformation
             Information about the simulation run.
         """
-        return_information = self.run(timeout)
+        warnings.warn(
+            message="Cadet.run_load() will be removed in a future release. Please use Cadet.run_simulation()",
+            category=FutureWarning
+        )
+        return_information = self.run_simulation(timeout=timeout, clear=clear)
+        return return_information
+
+    def run_simulation(
+            self,
+            timeout: Optional[int] = None,
+            clear: bool = True
+    ) -> ReturnInformation:
+        """
+        Run the CADET simulation and load the results.
+
+        Parameters
+        ----------
+        timeout : Optional[int]
+            Maximum time allowed for the simulation to run, in seconds.
+        clear : bool
+            If True, clean up the simulation after loading the results, e.g. reset the driver.
+
+        Returns
+        -------
+        ReturnInformation
+            Information about the simulation run.
+        """
+        return_information = self.cadet_runner.run(
+            simulation=self,
+            timeout=timeout
+        )
 
         if return_information.return_code == 0:
-            self.load_results()
+            self.cadet_runner.load_results(self)
 
         if clear:
             self.clear()
@@ -520,6 +550,10 @@ class Cadet(H5, metaclass=CadetMeta):
         ReturnInformation
             Information about the simulation run.
         """
+        warnings.warn(
+            message="Cadet.run() will be removed in a future release. Please use Cadet.run_simulation()",
+            category=FutureWarning
+        )
         return_information = self.cadet_runner.run(
             self,
             timeout=timeout,
@@ -529,9 +563,23 @@ class Cadet(H5, metaclass=CadetMeta):
 
     def load_results(self) -> None:
         """Load the results of the last simulation run into the current instance."""
-        runner = self.cadet_runner
-        if runner is not None:
-            runner.load_results(self)
+        warnings.warn(
+            message="Cadet.load_results() will be removed in a future release. \n"
+            "    Please use Cadet.load_from_file() to load results from a file \n"
+            "    or use Cadet.run_simulation() to run a simulation and directly load the simulation results.",
+            category=FutureWarning
+        )
+        self.load_from_file()
+
+    def load(self) -> None:
+        """Load the results of the last simulation run into the current instance."""
+        warnings.warn(
+            message="Cadet.load() will be removed in a future release. \n"
+            "    Please use Cadet.load_from_file() to load results from a file \n"
+            "    or use Cadet.run_simulation() to run a simulation and directly load the simulation results.",
+            category=FutureWarning
+        )
+        self.load_from_file()
 
     def clear(self) -> None:
         """Clear the loaded results from the current instance."""

--- a/cadet/cadet_dll.py
+++ b/cadet/cadet_dll.py
@@ -1710,9 +1710,9 @@ class CadetDLLRunner(CadetRunnerBase):
 
     def clear(self) -> None:
         """
-        Clear the current simulation state.
+        Clear the simulation results from the current instance.
 
-        This method deletes the current simulation results and resets the driver.
+        Note, this method deletes also resets the driver.
         """
         if hasattr(self, "res"):
             del self.res

--- a/cadet/h5.py
+++ b/cadet/h5.py
@@ -94,7 +94,7 @@ class H5:
         for i in data:
             self.root.update(copy.deepcopy(i))
 
-    def load(self, paths: Optional[List[str]] = None, update: bool = False, lock: bool = False) -> None:
+    def load_from_file(self, paths: Optional[List[str]] = None, update: bool = False, lock: bool = False) -> None:
         """
         Load data from the specified HDF5 file.
 
@@ -103,7 +103,8 @@ class H5:
         paths : Optional[List[str]], optional
             Specific paths to load within the HDF5 file.
         update : bool, optional
-            If True, updates the existing data with the loaded data.
+            If True, updates the existing data with the loaded data, i.e. keep existing data and ADD loaded data.
+            If False, discard existing data and only keep loaded data.
         lock : bool, optional
             If True, uses a file lock while loading.
         """

--- a/cadet/h5.py
+++ b/cadet/h5.py
@@ -1,9 +1,9 @@
-from typing import Optional, Union, Any, List
 import copy
 import json
-import pprint
-import warnings
 from pathlib import Path
+import pprint
+from typing import Optional, Any
+import warnings
 
 from addict import Dict
 with warnings.catch_warnings():
@@ -94,7 +94,12 @@ class H5:
         for i in data:
             self.root.update(copy.deepcopy(i))
 
-    def load_from_file(self, paths: Optional[List[str]] = None, update: bool = False, lock: bool = False) -> None:
+    def load_from_file(
+            self,
+            paths: Optional[list[str]] = None,
+            update: bool = False,
+            lock: bool = False
+            ) -> None:
         """
         Load data from the specified HDF5 file.
 
@@ -103,17 +108,22 @@ class H5:
         paths : Optional[List[str]], optional
             Specific paths to load within the HDF5 file.
         update : bool, optional
-            If True, updates the existing data with the loaded data, i.e. keep existing data and ADD loaded data.
+            If True, update the existing data with the loaded data,
+            i.e. keep existing data and ADD loaded data.
             If False, discard existing data and only keep loaded data.
         lock : bool, optional
             If True, uses a file lock while loading.
         """
         if self.filename is not None:
-            lock_file = filelock.FileLock(self.filename + '.lock') if lock else contextlib.nullcontext()
+            lock_file = filelock.FileLock(
+                    self.filename + '.lock'
+                ) if lock else contextlib.nullcontext()
 
             with lock_file:
                 with h5py.File(self.filename, 'r') as h5file:
-                    data = Dict(recursively_load(h5file, '/', self.inverse_transform, paths))
+                    data = Dict(
+                        recursively_load(h5file, '/', self.inverse_transform, paths)
+                    )
                     if update:
                         self.root.update(data)
                     else:
@@ -129,9 +139,16 @@ class H5:
         ----------
         lock : bool, optional
             If True, uses a file lock while saving.
+
+        Raises
+        ------
+        ValueError
+            If the filename is not set before attempting to save.
         """
         if self.filename is not None:
-            lock_file = filelock.FileLock(self.filename + '.lock') if lock else contextlib.nullcontext()
+            lock_file = filelock.FileLock(
+                    self.filename + '.lock'
+                ) if lock else contextlib.nullcontext()
 
             with lock_file:
                 with h5py.File(self.filename, 'w') as h5file:
@@ -181,7 +198,9 @@ class H5:
             If True, uses a file lock while appending.
         """
         if self.filename is not None:
-            lock_file = filelock.FileLock(self.filename + '.lock') if lock else contextlib.nullcontext()
+            lock_file = filelock.FileLock(
+                    self.filename + '.lock'
+                ) if lock else contextlib.nullcontext()
 
             with lock_file:
                 with h5py.File(self.filename, 'a') as h5file:
@@ -255,7 +274,7 @@ class H5:
         obj[parts[-1]] = value
 
 
-def convert_from_numpy(data: Dict, func: Optional[callable]=None) -> Dict:
+def convert_from_numpy(data: Dict, func: Optional[callable] = None) -> Dict:
     """
     Convert a dictionary with NumPy objects into native Python types.
 
@@ -295,7 +314,7 @@ def convert_from_numpy(data: Dict, func: Optional[callable]=None) -> Dict:
     return ans
 
 
-def recursively_load_dict(data: dict, func: Optional[callable]=None) -> Dict:
+def recursively_load_dict(data: dict, func: Optional[callable] = None) -> Dict:
     """
     Recursively load data from a dictionary.
 
@@ -355,7 +374,12 @@ def set_path(obj: Dict[str, Any], path: str, value: Any) -> None:
     temp[path_parts[-1]] = value
 
 
-def recursively_load(h5file: h5py.File, path: str, func: callable, paths: Optional[List[str]]) -> Dict:
+def recursively_load(
+        h5file: h5py.File,
+        path: str,
+        func: callable,
+        paths: Optional[list[str]]
+        ) -> Dict:
     """
     Recursively load data from an HDF5 file.
 
@@ -383,7 +407,9 @@ def recursively_load(h5file: h5py.File, path: str, func: callable, paths: Option
                 if isinstance(item, h5py._hl.dataset.Dataset):
                     set_path(ans, path, item[()])
                 elif isinstance(item, h5py._hl.group.Group):
-                    set_path(ans, path, recursively_load(h5file, path + '/', func, None))
+                    set_path(
+                        ans, path, recursively_load(h5file, path + '/', func, None)
+                    )
     else:
         for key_original in h5file[path].keys():
             key = func(key_original)
@@ -414,7 +440,8 @@ def recursively_save(h5file: h5py.File, path: str, dic: Dict, func: callable) ->
     Raises
     ------
     ValueError
-        If path or h5file types are invalid, or if the dictionary contains unsupported data types.
+        If path or h5file types are invalid, or if the dictionary contains unsupported
+        data types.
     """
     if not isinstance(path, str):
         raise ValueError("path must be a string")
@@ -443,12 +470,17 @@ def recursively_save(h5file: h5py.File, path: str, dic: Dict, func: callable) ->
             try:
                 value = numpy.array(item)
             except TypeError:
-                raise ValueError(f'Cannot save {path}/{func(key)} key with {type(item)} type.')
+                raise ValueError(
+                    f'Cannot save {path}/{func(key)} key with {type(item)} type.'
+                )
 
         try:
             h5file[path + func(key)] = value
         except OSError as e:
             if str(e) == 'Unable to create link (name already exists)':
-                raise KeyError(f'Name conflict with upper and lower case entries for key "{path}{key}".')
+                raise KeyError(
+                    'Name conflict with upper and lower case entries for key '
+                    f'"{path}{key}".'
+                )
             else:
                 raise

--- a/cadet/h5.py
+++ b/cadet/h5.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import os
 from pathlib import Path
 import pprint
 from typing import Optional, Any
@@ -155,6 +156,14 @@ class H5:
                     recursively_save(h5file, '/', self.root, self.transform)
         else:
             raise ValueError("Filename must be set before save can be used")
+
+    def delete_file(self) -> None:
+        """Delete the file associated with the current instance."""
+        if self.filename is not None:
+            try:
+                os.remove(self.filename)
+            except FileNotFoundError:
+                pass
 
     def save_json(self, filename: str | Path) -> None:
         """

--- a/cadet/runner.py
+++ b/cadet/runner.py
@@ -182,7 +182,7 @@ class CadetCLIRunner(CadetRunnerBase):
         sim : Cadet
             The simulation object where results will be loaded.
         """
-        sim.load(paths=["/meta", "/output"], update=True)
+        sim.load_from_file(paths=["/meta", "/output"], update=True)
 
     def _get_cadet_version(self) -> dict:
         """

--- a/tests/test_dll.py
+++ b/tests/test_dll.py
@@ -124,7 +124,7 @@ def setup_model(
         )
 
     cadet_model.filename = file_name
-    cadet_model.load()
+    cadet_model.load_from_file()
     if n_components < 4:
         unit_000 = cadet_model.root.input.model.unit_000
         unit_000.update({
@@ -182,7 +182,7 @@ def setup_model(
         cadet_model.save()
         cadet_model = Cadet(install_path=cadet_root, use_dll=use_dll)
         cadet_model.filename = file_name
-        cadet_model.load()
+        cadet_model.load_from_file()
 
     return cadet_model
 
@@ -324,7 +324,7 @@ def run_simulation_with_options(use_dll, model_options, solution_recorder_option
     model = setup_model(cadet_root, use_dll, **model_options)
     setup_solution_recorder(model, **solution_recorder_options)
 
-    return_info = model.run_load()
+    return_info = model.run_simulation()
 
     if return_info.return_code != 0:
         raise RuntimeError(return_info)

--- a/tests/test_h5.py
+++ b/tests/test_h5.py
@@ -51,7 +51,7 @@ def test_save_and_load_h5(h5_instance, temp_h5_file):
 
     new_instance = H5()
     new_instance.filename = temp_h5_file
-    new_instance.load()
+    new_instance.load_from_file()
 
     assert new_instance.root.keyString == b"value1"
     assert new_instance.root.keyInt == 42
@@ -91,7 +91,7 @@ def test_append_data(h5_instance, temp_h5_file):
 
     new_instance = H5()
     new_instance.filename = temp_h5_file
-    new_instance.load()
+    new_instance.load_from_file()
 
     assert new_instance.root.key4 == b"new_value"
 
@@ -161,7 +161,7 @@ def test_load_nonexistent_file():
     instance = H5()
     instance.filename = "nonexistent_file.h5"
     with pytest.raises(OSError):
-        instance.load()
+        instance.load_from_file()
 
 
 def test_save_without_filename(h5_instance):

--- a/tests/test_install_path_settings.py
+++ b/tests/test_install_path_settings.py
@@ -24,6 +24,8 @@ def test_autodetection():
 
 @pytest.mark.local
 def test_install_path():
+    if full_path_dll == Path("path/to/cadet"):
+        raise ValueError("This test requires a secondary CADET installation. Please set the full_path_dll variable.")
     sim = Cadet(install_path=full_path_dll, use_dll=True)
     assert sim.cadet_dll_path == full_path_dll
     assert sim.cadet_runner.cadet_path.suffix in [".dll", ".so"]
@@ -45,6 +47,8 @@ def test_install_path():
 
 @pytest.mark.local
 def test_dll_runner_attrs():
+    if full_path_dll == Path("path/to/cadet"):
+        raise ValueError("This test requires a secondary CADET installation. Please set the full_path_dll variable.")
     cadet = Cadet(full_path_dll.parent.parent)
     cadet_runner = cadet._cadet_dll_runner
     assert re.match(r"\d\.\d\.\d", cadet_runner.cadet_version)
@@ -56,6 +60,8 @@ def test_dll_runner_attrs():
 
 @pytest.mark.local
 def test_cli_runner_attrs():
+    if full_path_dll == Path("path/to/cadet"):
+        raise ValueError("This test requires a secondary CADET installation. Please set the full_path_dll variable.")
     cadet = Cadet(full_path_dll.parent.parent)
     cadet_runner = cadet._cadet_cli_runner
     assert re.match(r"\d\.\d\.\d", cadet_runner.cadet_version)

--- a/tests/test_meta_class_install_path.py
+++ b/tests/test_meta_class_install_path.py
@@ -14,6 +14,8 @@ install_path_conda = Cadet.autodetect_cadet()
 
 @pytest.mark.local
 def test_meta_class():
+    if full_path_dll == Path("path/to/cadet"):
+        raise ValueError("This test requires a secondary CADET installation. Please set the full_path_dll variable.")
     Cadet.cadet_path = full_path_dll
     assert Cadet.use_dll
 

--- a/tests/test_parallelization.py
+++ b/tests/test_parallelization.py
@@ -7,7 +7,7 @@ n_jobs = 2
 
 def run_simulation(model):
     model.save()
-    data = model.run_load()
+    data = model.run_simulation()
     model.delete_file()
 
     return data


### PR DESCRIPTION
As discussed in https://github.com/cadet/CADET-Python/issues/27 we would like to remove ambiguity in the interface between the cadet.run, cadet.run_load and cadet.load functions. Therefore we have decided to add new default interfaces of .run_simulation and .load_from_file. .run_simulation takes the place of .run_load and should be the clear interaction point for users wanting to run a simulation. .load_from_file replaces .load but makes it clear that it only loads the data from a given file.