### PR TITLE
Flatten Multidimensional Arrays to fix MCT CAPI Issues

### DIFF
--- a/cadet/cadet_dll_utils.py
+++ b/cadet/cadet_dll_utils.py
@@ -229,7 +229,7 @@ def param_provider_get_double_array(
 
     # Provide array data to the caller
     n_elem[0] = ctypes.c_int(o.size)
-    val[0] = np.ctypeslib.as_ctypes(o)
+    val[0] = np.ctypeslib.as_ctypes(o.ravel())
 
     log_print(f"GET array [double] {n}: {o}")
     return 0


### PR DESCRIPTION
### **Issue**

This PR fixes issue https://github.com/fau-advanced-separations/CADET-Process/issues/236, where CADET-Process fails to retrieve the `EXCHANGE_MATRIX` when provided as a **multidimensional NumPy array**.

When `EXCHANGE_MATRIX` is passed as a **multi-dimensional array**, `np.ctypeslib.as_ctypes(o)` throws: `TypeError: incompatible types, c_double_Array_4_Array_3_Array_3 instance instead of LP_c_double instance` in CADET-Python.

This happens because `o` in this case is a **nested NumPy array** instead of a **flat (1D) contiguous array**, which CADET's C API expects.

### **Fix**
Flattening the array before processing resolves the issue:

```python
val[0] = np.ctypeslib.as_ctypes(o.ravel())  
```


### **Open questions**

**Does this break anything else? Is there a better / more elegant way to do this?**

All CADET-Process and CADET-Python tests still pass on my Windows machine.
The MCT now works correctly with the C API.

**Why does this issue not occur in the CI pipeline and for Jo's Linux system?**

Maybe this is still caused by different NumPy versions or platform-specific memory handling, but I haven’t found a specific NumPy version that fixes or causes the issue.


