### PR TITLE
Add deprecation warning for timeout in run method(s)

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -518,16 +518,29 @@ class Cadet(H5, metaclass=CadetMeta):
 
         Parameters
         ----------
-        timeout : Optional[int]
-            Maximum time allowed for the simulation to run, in seconds.
-        clear : bool
-            If True, clear the simulation results from the current runner instance.
+        timeout : Optional[int], default=None
+            Maximum simulation runtime in seconds.
+
+        clear : bool, default=True
+            Clear previous results before loading new ones.
 
         Returns
         -------
         ReturnInformation
-            Information about the simulation run.
+            Simulation run details and results.
+
+        Warnings
+        --------
+        The `timeout` parameter is deprecated. Set the timeout in the solver options
+        instead.
         """
+        if timeout is not None:
+            warnings.warn(
+                "Support for setting timeout via `run_simulation` will be removed in a "
+                " future version. Please set the value in the solver options instead.",
+                FutureWarning
+            )
+
         return_information = self.cadet_runner.run(
             simulation=self,
             timeout=timeout

--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -514,7 +514,7 @@ class Cadet(H5, metaclass=CadetMeta):
             clear: bool = True
     ) -> ReturnInformation:
         """
-        Run the CADET simulation and load the results.
+        Execute the CADET simulation and load the results.
 
         Parameters
         ----------

--- a/cadet/cadet_dll.py
+++ b/cadet/cadet_dll.py
@@ -3,6 +3,7 @@ import io
 import os
 from pathlib import Path
 from typing import Any, Optional
+import warnings
 
 import addict
 import numpy
@@ -1782,7 +1783,19 @@ class CadetDLLRunner(CadetRunnerBase):
         ------
         RuntimeError
             If the simulation process returns a non-zero exit code.
+
+        Warnings
+        --------
+        The `timeout` parameter is deprecated. Set the timeout in the solver options
+        instead.
         """
+        if timeout is not None:
+            warnings.warn(
+                "Support for setting timeout via `run_simulation` will be removed in a "
+                " future version. Please set the value in the solver options instead.",
+                FutureWarning
+            )
+
         pp = cadet_dll_parameterprovider.PARAMETERPROVIDER(simulation)
 
         log_buffer = self.setup_log_buffer()

--- a/cadet/runner.py
+++ b/cadet/runner.py
@@ -1,10 +1,9 @@
-import os
-import pathlib
-import re
-import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import os
 from pathlib import Path
+import re
+import subprocess
 from typing import Optional
 
 
@@ -16,12 +15,14 @@ class ReturnInformation:
     Parameters
     ----------
     return_code : int
-        An integer representing the return code. 0 indicates success, non-zero values indicate errors.
+        An integer representing the return code.
+        0 indicates success, non-zero values indicate errors.
     error_message : str
         A string containing the error message if an error occurred. Empty if no error.
     log : str
         A string containing log information.
     """
+
     return_code: int
     error_message: str
     log: str
@@ -59,9 +60,7 @@ class CadetRunnerBase(ABC):
 
     @abstractmethod
     def clear(self) -> None:
-        """
-        Clear the simulation data.
-        """
+        """Clear the simulation data."""
         pass
 
     @abstractmethod
@@ -147,6 +146,11 @@ class CadetCLIRunner(CadetRunnerBase):
         -------
         ReturnInformation
             Information about the simulation run.
+
+        Warnings
+        --------
+        The `timeout` parameter is deprecated. Set the timeout in the solver options
+        instead.
         """
         if simulation.filename is None:
             raise ValueError("Filename must be set before run can be used")
@@ -187,10 +191,12 @@ class CadetCLIRunner(CadetRunnerBase):
     def _get_cadet_version(self) -> dict:
         """
         Get version and branch name of the currently instanced CADET build.
+
         Returns
         -------
         dict
-            Dictionary containing: cadet_version as x.x.x, cadet_branch, cadet_build_type, cadet_commit_hash
+            Dictionary containing: cadet_version as x.x.x,
+            cadet_branch, cadet_build_type, cadet_commit_hash
         Raises
         ------
         ValueError

--- a/cadet/runner.py
+++ b/cadet/runner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import subprocess
 from typing import Optional
+import warnings
 
 
 @dataclass
@@ -39,7 +40,6 @@ class CadetRunnerBase(ABC):
     def run(
             self,
             simulation: "Cadet",
-            timeout: Optional[int] = None,
     ) -> ReturnInformation:
         """
         Run a CADET simulation.
@@ -48,8 +48,6 @@ class CadetRunnerBase(ABC):
         ----------
         simulation : Cadet
             The simulation object.
-        timeout : Optional[int]
-            Maximum time allowed for the simulation to run, in seconds.
 
         Returns
         -------
@@ -152,6 +150,12 @@ class CadetCLIRunner(CadetRunnerBase):
         The `timeout` parameter is deprecated. Set the timeout in the solver options
         instead.
         """
+        if timeout is not None:
+            warnings.warn(
+                "Support for setting timeout via `run_simulation` will be removed in a "
+                " future version. Please set the value in the solver options instead.",
+                FutureWarning
+            )
         if simulation.filename is None:
             raise ValueError("Filename must be set before run can be used")
 


### PR DESCRIPTION
This PR adds deprecation warnings for the timeout argument in run methods. This can now be set in the solver parameters (see https://github.com/cadet/CADET-Core/pull/366).