### PR TITLE
Add dependency group

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          conda run pip install .[testing]
+          conda run pip install . --group testing
           conda install -c conda-forge cadet>=5.0.3
           pytest tests --rootdir=tests -m "not slow and not local"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "filelock",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 testing = [
     "pytest",
     "joblib"


### PR DESCRIPTION
Adding dependency groups and splitting optional dependencies so that optional dependencies like ax are actual additional optional features where as dependency groups are dependencies used for special use cases like developing. To install dependency groups like dev in the future you have to use ```pip install . --group  testing```
