### PR TITLE
Expand user when setting install path

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -52,7 +52,7 @@ def resolve_cadet_paths(
     if install_path is None:
         return None, None, None, None
 
-    install_path = Path(install_path)
+    install_path = Path(install_path).expanduser()
 
     if install_path.is_file():
         cadet_root = install_path.parent.parent

--- a/tests/test_install_path_settings.py
+++ b/tests/test_install_path_settings.py
@@ -11,6 +11,7 @@ from cadet import Cadet
 
 # Full path to cadet.dll or cadet.so, that is different from the system/conda cadet
 full_path_dll = Path("path/to/cadet")
+home_path_dll = Path("path/to/cadet")
 
 install_path_conda = Cadet.autodetect_cadet()
 
@@ -22,6 +23,7 @@ def test_autodetection():
     assert sim.cadet_cli_path.parent.parent == install_path_conda
     assert sim.cadet_runner.cadet_path.suffix not in [".dll", ".so"]
 
+
 @pytest.mark.local
 def test_install_path():
     if full_path_dll == Path("path/to/cadet"):
@@ -30,12 +32,21 @@ def test_install_path():
     assert sim.cadet_dll_path == full_path_dll
     assert sim.cadet_runner.cadet_path.suffix in [".dll", ".so"]
 
+    # Set root directory of CADET installation
     sim = Cadet()
     sim.install_path = full_path_dll.parent.parent
     sim.use_dll = True
     assert sim.cadet_dll_path == full_path_dll
     assert sim.cadet_runner.cadet_path.suffix in [".dll", ".so"]
 
+    # Set root directory of CADET installation (with user home (`~`))
+    sim = Cadet()
+    sim.install_path = home_path_dll.parent.parent
+    sim.use_dll = True
+    assert sim.cadet_dll_path == full_path_dll
+    assert sim.cadet_runner.cadet_path.suffix in [".dll", ".so"]
+
+    # Set cli/dll path (deprecated)
     sim = Cadet()
     with pytest.deprecated_call():
         sim.cadet_path = full_path_dll.parent.parent


### PR DESCRIPTION
This PR expands the user when setting the CADET install path. Note, the tests are currently set to only run locally, i.e. when the dev has set a specific CADET install path on their machine. @jbreue16 Could you please check if this also works properly on Windows?