### PR TITLE
Fix autodetection of CADET executables on Windows PyPI installs

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -72,14 +72,22 @@ def resolve_cadet_paths(
         cli_executable += '.exe'
         lwe_executable += '.exe'
 
-    cadet_cli_path = cadet_root / 'bin' / cli_executable
-    if not cadet_cli_path.is_file():
+    # On Windows PyPI installs, scripts land in Scripts/ instead of bin/.
+    def _find_in_prefix(name: str) -> Optional[Path]:
+        for subdir in ('bin', 'Scripts'):
+            p = cadet_root / subdir / name
+            if p.is_file():
+                return p
+        return None
+
+    cadet_cli_path = _find_in_prefix(cli_executable)
+    if cadet_cli_path is None:
         raise FileNotFoundError(
             "CADET CLI could not be found. Please check the path."
         )
 
-    cadet_create_lwe_path = cadet_root / 'bin' / lwe_executable
-    if not cadet_create_lwe_path.is_file():
+    cadet_create_lwe_path = _find_in_prefix(lwe_executable)
+    if cadet_create_lwe_path is None:
         raise FileNotFoundError(
             "CADET createLWE could not be found. Please check the path."
         )


### PR DESCRIPTION
When `cadet-core is installed via PyPI on Windows, `cadet-cli.exe` and `createLWE.exe` are placed in `Scripts/` rather than `bin/`. The autodetection logic correctly resolves the prefix root via `shutil.which`, but `resolve_cadet_paths` only searched `bin/`, causing a `FileNotFoundError` on Windows.

This fix tries `bin/` first (preserving existing behaviour on Linux, macOS, and manual installs), then falls back to `Scripts/` for the Windows PyPI layout.