### PR TITLE
Add function to return CADET-Core commit hash

### DIFF
--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -389,6 +389,11 @@ class Cadet(H5, metaclass=CadetMeta):
         return self.cadet_runner.cadet_version
 
     @property
+    def commit_hash(self) -> str:
+        """str: The commit hash of the CADET-Core installation."""
+        return self.cadet_runner.cadet_commit_hash
+
+    @property
     def cadet_runner(self) -> CadetRunnerBase:
         """
         Get the current CADET runner instance.


### PR DESCRIPTION
I was surprised that this wasn't there yet. Useful e.g. in cadet-verification github actions to make sure we are pulling and testing the correct version.
@schmoelder did i overlook this functionality somewhere?