### PR TITLE
Add dll binary path for cadet core pypi distribution

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,3 +75,33 @@ jobs:
           conda install -c conda-forge cadet>=5.0.3
           pytest tests --rootdir=tests -m "not slow and not local"
 
+  test-pypi-job:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12", "3.13"]
+        include:
+          - os: windows-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.12"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install CADET-Python and cadet-core (PyPI)
+        run: |
+          pip install . --group testing
+          pip install cadet-core
+
+      - name: Test with pytest
+        run: |
+          pytest tests --rootdir=tests -m "not slow and not local"
+

--- a/cadet/cadet.py
+++ b/cadet/cadet.py
@@ -93,20 +93,47 @@ def resolve_cadet_paths(
         )
 
     if platform.system() == 'Windows':
-        dll_path = cadet_root / 'bin' / 'cadet.dll'
-        dll_debug_path = cadet_root / 'bin' / 'cadet_d.dll'
+        dll_dir = cadet_root / 'bin'
+        dll_names = ['cadet.dll']
+        dll_debug_names = ['cadet_d.dll']
     elif platform.system() == 'Darwin':
-        dll_path = cadet_root / 'lib' / 'libcadet.dylib'
-        dll_debug_path = cadet_root / 'lib' / 'libcadet_d.dylib'
+        dll_dir = cadet_root / 'lib'
+        # The unversioned name is a symlink to the SONAME-versioned file and may not
+        # survive wheel packaging, so also look for the versioned file directly.
+        dll_names = ['libcadet.dylib', 'libcadet.0.dylib']
+        dll_debug_names = ['libcadet_d.dylib', 'libcadet_d.0.dylib']
     else:
-        dll_path = cadet_root / 'lib' / 'libcadet.so'
-        dll_debug_path = cadet_root / 'lib' / 'libcadet_d.so'
+        dll_dir = cadet_root / 'lib'
+        dll_names = ['libcadet.so']
+        dll_debug_names = ['libcadet_d.so']
+
+    def _find_dll(directory: Path, names: list[str]) -> Optional[Path]:
+        for name in names:
+            p = directory / name
+            if p.is_file():
+                return p
+        return None
 
     # Look for debug dll if dll is not found.
-    if not dll_path.is_file() and dll_debug_path.is_file():
-        dll_path = dll_debug_path
+    cadet_dll_path = _find_dll(dll_dir, dll_names) or _find_dll(dll_dir, dll_debug_names)
 
-    cadet_dll_path = dll_path if dll_path.is_file() else None
+    # On PyPI cadet-core installs, cadet-cli/createLWE may be console-script wrappers
+    # whose enclosing prefix does not match the prefix that the cadet_core package
+    # (and its shared library) was actually installed into. If the dll could not be
+    # found under cadet_root, fall back to the cadet_core package directory directly.
+    if cadet_dll_path is None:
+        try:
+            import cadet_core
+            package_dir = Path(cadet_core.__file__).parent
+        except ImportError:
+            package_dir = None
+
+        if package_dir is not None:
+            package_dll_dir = package_dir / dll_dir.name
+            cadet_dll_path = (
+                _find_dll(package_dll_dir, dll_names)
+                or _find_dll(package_dll_dir, dll_debug_names)
+            )
 
     return root_path, cadet_cli_path, cadet_dll_path, cadet_create_lwe_path
 

--- a/tests/test_cadet.py
+++ b/tests/test_cadet.py
@@ -2,7 +2,7 @@
 Test general properties of Cadet.
 """
 
-
+from pathlib import Path
 import re
 import pytest
 from cadet import Cadet
@@ -14,6 +14,26 @@ def test_version(use_dll):
     cadet = Cadet(use_dll=use_dll)
 
     assert re.match(r"\d\.\d\.\d", cadet.version), "Version format should be X.X.X"
+
+
+@pytest.mark.parametrize("install_path", [
+    pytest.param(None, id="conda"),
+    pytest.param("pypi", id="pypi"),
+])
+def test_create_lwe_and_run_cli_smoke(install_path, tmp_path):
+    """createLWE + cadet-cli smoke test for both the conda and the PyPI install."""
+    if install_path == "pypi":
+        cadet_core = pytest.importorskip("cadet_core")
+        install_path = Path(cadet_core.__file__).parent
+    else:
+        install_path = Cadet.autodetect_cadet()
+
+    cadet = Cadet(install_path=install_path, use_dll=False)
+
+    model = cadet.create_lwe(file_path=tmp_path / "LWE.h5")
+    return_information = model.run_simulation()
+
+    assert return_information.return_code == 0
 
 
 if __name__ == '__main__':

--- a/tests/test_install_path_settings.py
+++ b/tests/test_install_path_settings.py
@@ -19,8 +19,11 @@ install_path_conda = Cadet.autodetect_cadet()
 def test_autodetection():
     sim = Cadet()
     assert sim.install_path == install_path_conda
-    assert sim.cadet_dll_path.parent.parent == install_path_conda
-    assert sim.cadet_cli_path.parent.parent == install_path_conda
+    # On some installs (e.g. cadet-core from PyPI), cadet-cli and the shared library
+    # are not necessarily nested under the same root, so only check that both were
+    # actually found rather than asserting a shared parent directory.
+    assert sim.cadet_dll_path is not None and sim.cadet_dll_path.is_file()
+    assert sim.cadet_cli_path is not None and sim.cadet_cli_path.is_file()
     assert sim.cadet_runner.cadet_path.suffix not in [".dll", ".so"]
 
 


### PR DESCRIPTION
Fixes and add tests for #77 

When this PR is merged we should to a bug fix release!

## Summary

Make CADET-Python correctly find the CADET-Core DLL when installed via the `cadet-core` PyPI package (not just conda), and add CI coverage for that install path.

1. **`cadet/cadet.py`** : `resolve_cadet_paths` now falls back to the `cadet_core` package's own directory (`Path(cadet_core.__file__).parent`) to locate the shared library whenever it isn't found under the originally-resolved root. This handles two PyPI problems: binaries nested inside `site-packages/cadet_core/` rather than at the venv root, and (discovered via CI) `cadet-cli`/`createLWE` console scripts sometimes living in a completely different prefix than the `cadet_core` package itself (seen on macOS GH Actions runners). Also added the SONAME-versioned `libcadet.0.dylib` as a fallback filename on macOS.

2. **`tests/test_cadet.py`** : new `test_create_lwe_and_run_cli_smoke`, parametrized over the conda-autodetected install and the `cadet-core` PyPI install (skipped via `pytest.importorskip` if `cadet_core` isn't present). Runs `create_lwe()` + `run_simulation()` and checks for a clean return code.

3. **`.github/workflows/pipeline.yml`** : new `test-pypi-job`: a plain-Python (no conda) matrix job that `pip install`s CADET-Python + `cadet-core` and runs the test suite, exercising the PyPI install path end-to-end across Linux/Windows/macOS.

4. **`tests/test_install_path_settings.py`** : relaxed `test_autodetection` to check that `cadet_dll_path`/`cadet_cli_path` exist rather than asserting they share a parent directory with the install root, since  that invariant doesn't hold for PyPI installs where the dll and the console scripts can live under different prefixes.
